### PR TITLE
feat: automated configuration of user subnets in RouterOS role

### DIFF
--- a/ansible/memphis.yml
+++ b/ansible/memphis.yml
@@ -14,6 +14,13 @@ memphis:
           ether1_ip: 44.34.129.115
         r1.crw.memhamwan.net:
           ether1_ip: 44.34.129.116
+          user_subnets:
+            - name: OBARC
+              network: "44.34.129.176/28"
+              gateway_ip: "44.34.129.176/28"
+              bridge_ports:
+                - "ether7"
+                - "ether8"
         r2.crw.memhamwan.net:
           ether1_ip: 44.34.129.117
         r3.crw.memhamwan.net:

--- a/ansible/roles/routeros/tasks/main.yml
+++ b/ansible/roles/routeros/tasks/main.yml
@@ -15,6 +15,16 @@
         - harden
   tags:
     - harden
+- name: Include user_subnets tasks
+  include_tasks: 
+    file: "user_subnets.yml"
+    apply:
+      tags:
+        - user_subnets
+  loop: "{{ user_subnets }}"
+  when: "user_subnets is defined"
+  tags:
+    - user_subnets
 - name: Setup manual users
   community.network.routeros_command:
     commands: 

--- a/ansible/roles/routeros/tasks/user_subnets.yml
+++ b/ansible/roles/routeros/tasks/user_subnets.yml
@@ -1,0 +1,51 @@
+---
+- name: Get list of bridge interfaces
+  community.network.routeros_command:
+    commands: "/interface bridge export"
+  register: get_bridge_results
+
+- name: Add the bridge interface
+  community.network.routeros_command:
+    commands: "/interface bridge add name={{ item.name }}"
+  register: add_bridge_results
+  failed_when: "'failure' in add_bridge_results.stdout[0]"
+  when: get_bridge_results.stdout[0].find("name="+item.name+"\n") == -1
+  changed_when: True
+
+- name: Get list of IP addresses
+  community.network.routeros_command:
+    commands: "/ip address export"
+  register: get_address_results
+
+- name: Add the IP address
+  community.network.routeros_command:
+    commands: "/ip address add address={{ item.gateway_ip }} interface={{ item.name }}"
+  register: add_address_results
+  failed_when: "'failure' in add_address_results.stdout[0]"
+  when: get_address_results.stdout[0].find("address="+item.gateway_ip+" ") == -1
+  changed_when: True
+
+
+- name: Get list of networks
+  community.network.routeros_command:
+    commands: "/routing ospf network export"
+  register: get_ospf_network_results
+
+- name: Add the network to OSPF
+  community.network.routeros_command:
+    commands: "/routing ospf network add area=backbone network={{ item.network }}"
+  register: add_ospf_network_results
+  when: get_ospf_network_results.stdout[0].find("network="+item.network) == -1
+  changed_when: True
+
+# TODO: make this handle registering changes in ansible
+# TODO: make this not remove the port every time
+- name: Remove and add ports to bridge
+  community.network.routeros_command:
+    commands:
+      - "/interface bridge port remove [find interface={{inner_item}}]"
+      - "/interface bridge port add bridge={{ item.name }} interface={{inner_item}}"
+  loop: "{{item.bridge_ports}}"
+  loop_control:
+    loop_var: inner_item
+  register: remove_and_add_port_results


### PR DESCRIPTION
See example in the inventory file for crw. This is a naive configuration that doesn't handle all errors -- limitations are stated in the user_subnets.yml file, plus standard field delimiter limitations apply.

Closes #12.