### PR TITLE
Make routeros upgrade and add user work

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,5 +1,5 @@
 name: linters
-on: push
+on: push  # yamllint disable-line rule:truthy
 jobs:
   my-job:
     runs-on: ubuntu-latest
@@ -7,8 +7,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: pip3 install -r requirements.txt
-      - run: yamllint **/*.yaml
-  ansible-lint: 
+      - run: yamllint .
+  ansible-lint:
     runs-on: ubuntu-latest
     name: Ansible Lint
     steps:

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -22,7 +22,7 @@ rules:
   indentation: enable
   key-duplicates: enable
   key-ordering: disable
-  line-length: 
+  line-length:
     max: 160
   new-line-at-end-of-file: enable
   new-lines: enable

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -14,7 +14,7 @@
 This will update routeros and then the routerboard firmware for every routeros device. "Changed" status is accurate -- devices that just show "OK" were already up-to-date.
 
 ```bash
-ansible-playbook --vault-password-file .vault-password -i memphis.yaml configure-routeros.yaml --tags update
+ansible-playbook --vault-password-file .vault-password -i memphis.yaml upgrade-routeros.yaml --tags update,add-users
 ```
 
 ### Base Linux Setup

--- a/ansible/configure-routeros.yaml
+++ b/ansible/configure-routeros.yaml
@@ -1,5 +1,27 @@
 ---
-- hosts: routeros
+# Upgrade all devices, but run in a specific order so that it works site-by-site; the intent here is to minimize the impact of this maintenance
+# First of all, start with the omnis etc that can all be done with a high serial number; these are not SPOFs for the network
+- hosts: routeros:&ret
+  roles:
+    - role: routeros
+  gather_facts: false
+  serial: 1
+- hosts: routeros:&sco
+  roles:
+    - role: routeros
+  gather_facts: false
+  serial: 1
+- hosts: routeros:&azo
+  roles:
+    - role: routeros
+  gather_facts: false
+  serial: 1
+- hosts: routeros:&hil
+  roles:
+    - role: routeros
+  gather_facts: false
+  serial: 1
+- hosts: routeros:&leb
   roles:
     - role: routeros
   gather_facts: false

--- a/ansible/memphis.yaml
+++ b/ansible/memphis.yaml
@@ -1,9 +1,10 @@
 memphis:
   vars:
-    ansible_command_timeout: 45
-    ansible_port: 222
+    ssh_port: 222
     dns_server: 44.34.128.190
     ntp_server: ntp.memhamwan.net
+    ansible_command_timeout: 45
+    ansible_port: "{{ssh_port}}"
     users:
       - name: turnrye
         key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDEZXA4eMYwloBRhd7bvYVF8o+xBUHLCldQcSfwunhE+OP8g13a5/DsUL+XkM14MNxLgIZaTKwLQxN8Q0O7WyVy9ZRCS29ybGvjhzMi3YJE\
@@ -29,10 +30,10 @@ memphis:
                 - "ether8"
         r2.crw.memhamwan.net:
           ether1_ip: 44.34.129.117
-        r3.crw.memhamwan.net:
-          ether1_ip: 44.34.129.118
-        omn1.crw.memhamwan.net:
-          ether1_ip: 44.34.129.114
+        # r3.crw.memhamwan.net:
+        #   ether1_ip: 44.34.129.118
+        # omn1.crw.memhamwan.net:
+        #   ether1_ip: 44.34.129.114
         omn2.crw.memhamwan.net:
           ether1_ip: 44.34.129.119
       vars:
@@ -203,8 +204,8 @@ memphis:
         leb.crw.memhamwan.net:
         r1.crw.memhamwan.net:
         r2.crw.memhamwan.net:
-        r3.crw.memhamwan.net:
-        omn1.crw.memhamwan.net:
+        # r3.crw.memhamwan.net:
+        # omn1.crw.memhamwan.net:
         omn2.crw.memhamwan.net:
         leb.ret.memhamwan.net:
     servers:

--- a/ansible/roles/routeros/tasks/add_netops.yml
+++ b/ansible/roles/routeros/tasks/add_netops.yml
@@ -1,0 +1,9 @@
+---
+- name: "Add user {{ item.name }}"
+  community.network.routeros_command:
+    commands:
+      - "/file set {{ item.name }} contents='{{ item.key }}'"
+      - "/user add name={{ item.name }} group=full"
+      - "/user ssh-keys import public-key-file={{ item.name }}.keys user={{ item.name }}"
+  changed_when: true
+  when: item.name not in existing_users

--- a/ansible/roles/routeros/tasks/harden.yaml
+++ b/ansible/roles/routeros/tasks/harden.yaml
@@ -42,9 +42,9 @@
     commands:
       - ":put [/ip service get [find name=ssh]]"
   register: ssh_service
-- name: Move SSH to port 222
+- name: "Move SSH to port {{ ssh_port }}"
   community.network.routeros_command:
     commands:
-      - "/ip service set ssh port=222"
+      - "/ip service set ssh port={{ ssh_port }}"
   when: ssh_service.stdout_lines[0][0] is not regex("(^|;)port=222(;|$)")
   changed_when: true

--- a/ansible/roles/routeros/tasks/main.yaml
+++ b/ansible/roles/routeros/tasks/main.yaml
@@ -25,12 +25,24 @@
   when: "user_subnets is defined"
   tags:
     - user_subnets
-- name: Setup manual users
+- name: Get list of users on live
   community.network.routeros_command:
     commands:
-      - "/file set {{ item.name }} contents='{{ item.key }}'"
-      - "/user add name={{ item.name }} group=full"
-      - "/user ssh-keys import public-key-file={{ item.name }}.keys user={{ item.name }}"
+      - ":foreach i in=[ /user print as-value ] do={:put ($i->\"name\")}"
+  register: existing_users_raw
+  tags:
+    - add-users
+- name: Parse ROS output and set existing_users variable
+  set_fact:
+    existing_users: "{{ existing_users_raw.stdout[0].split('\n\n')[1].split('\n') }}"
+  tags:
+    - add-users
+- name: Setup netops users
+  include_tasks:
+    file: "add_netops.yml"
+    apply:
+      tags:
+        - add-users
   loop: "{{ users }}"
   tags:
     - add-users

--- a/ansible/roles/routeros/tasks/update.yaml
+++ b/ansible/roles/routeros/tasks/update.yaml
@@ -23,7 +23,7 @@
 - name: Wait for server to restart  # noqa no-handler
   wait_for:
     host: "{{ inventory_hostname }}"
-    port: 22
+    port: "{{ ssh_port }}"
     delay: 20
   delegate_to: localhost
   when: package_update.changed
@@ -38,10 +38,12 @@
       - ":execute script=\"/system reboot\""
   when: firmware_version.stdout_lines[0][-1].split(' ')[-1] != firmware_version.stdout_lines[0][-2].split(' ')[-1]
   changed_when: true
+  async: 120
+  poll: 5
 - name: Wait for server to restart
   wait_for:
     host: "{{ inventory_hostname }}"
-    port: 22
+    port: "{{ ssh_port }}"
     delay: 20
   delegate_to: localhost
   when: firmware_version.stdout_lines[0][-1].split(' ')[-1] != firmware_version.stdout_lines[0][-2].split(' ')[-1]


### PR DESCRIPTION
There were a few issues with routeros upgade:

- It didn't work after the port 22 -> 222 SSH migration
- It kept timing out on the firmware step
- The playbook for upgrade didnt specify any specific order, and it let 3 hosts run at a time; this kept leading to network interruptions on one while another was upgrading (e.g. if you upgrade a site core router in the middle of upgrading its sectors, suddenly you'll see the sector fail)
- The add user piece would always result in user change, it was not checking to see if they existed before going forward with adding the user

This addresses all of those issues/concerns.

Related to #16 

Along the way, I also widened the scope of yamllint to all yaml files in the repo, and fixed a few issues there too.

![Screenshot from 2021-06-20 13-04-17](https://user-images.githubusercontent.com/701035/122683935-0acfff80-d1c8-11eb-984a-2dfbc27e424f.png)
