### PR TITLE
Upgrade blackbox exporter to v0.19

### DIFF
--- a/fleet/prometheus-blackbox-exporter/fleet.yaml
+++ b/fleet/prometheus-blackbox-exporter/fleet.yaml
@@ -4,7 +4,7 @@ helm:
   values:
     image:
       repository: prom/blackbox-exporter
-      tag: v0.18.0
+      tag: v0.19.0
       pullPolicy: IfNotPresent
     ingress:
       enabled: "true"
@@ -17,7 +17,6 @@ helm:
           timeout: 5s
           http:
             valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
-            no_follow_redirects: false
             preferred_ip_protocol: "ip4"
         tcp_connect:
           prober: tcp


### PR DESCRIPTION
# What

Upgrade blackbox exporter to the newest version, and address a config format difference for it to work

# Why

Blackbox exporter just stopped working. The logs show that it must be because of a problem related to 0.18, maybe they had an external dependency change that wasn't pinned? I dont know. We were definitely on 0.18 and it definitely worked, then it restarted and stopped working.

```
Tue, Jun 22 2021 6:20:20 am | level=info ts=2021-06-22T11:20:20.199Z caller=main.go:212 msg="Starting blackbox_exporter" version="(version=0.18.0, branch=HEAD, revision=60c86e6ce5a1111f7958b06ae7a08222bb6ec839)"
Tue, Jun 22 2021 6:20:20 am | level=info ts=2021-06-22T11:20:20.199Z caller=main.go:213 msg="Build context" (gogo1.15.2,userroot@53d72328d93f,date20201012-09:46:31)=(MISSING)
Tue, Jun 22 2021 6:20:20 am | level=error ts=2021-06-22T11:20:20.199Z caller=main.go:216 msg="Error loading config" err="error parsing config file: yaml: unmarshal errors:\n line 4: field follow_redirects not found in type config.plain"
```

# How

Just bump the version in the tag and fix the config

# Test

We'll do it live